### PR TITLE
Add missing "exec" import

### DIFF
--- a/src/version.js
+++ b/src/version.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const Promise = require('promise');
 const write = Promise.denodeify(fs.writeFile);
 const colors = require('colors');
-
+const exec = require('child_process').exec;
 
 var getPackageJson = function(repo) {
   return repo.getHeadCommit().then(function(commit) {


### PR DESCRIPTION
My last PR was missing this one line. After adding the import, I was able to start a release branch successfully.